### PR TITLE
sync only wordpress directory.

### DIFF
--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -119,7 +119,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = WP_HOSTNAME
   config.vm.network :private_network, ip: WP_IP
 
-  config.vm.synced_folder "www/", "/var/www", :create => "true"
+  config.vm.synced_folder "www/wordpress/", "/var/www/wordpress", :create => "true"
 
   config.hostsupdater.remove_on_suspend = true
 


### PR DESCRIPTION
At least on my Windows 8.1, apache2 installation is failed at provision phase.

In recent httpd rpm,  symlink is used somewhere, but in synced folder symlink is prohibited(causes protocol error.)
Because on Windows 8, normal user is prohibited creating symlink (also mklink command fails). Only administrator can.

So, if other /var/www files do not have to be synced, just sync wordpress directory and the problem is avoided.

Thanks.
