### PR TITLE
Remove git:// in favor of https://

### DIFF
--- a/cookbooks/apache2/CONTRIBUTING.md
+++ b/cookbooks/apache2/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Each ticket should aim to fix one bug or add one feature.
 
 You can get a quick copy of the repository for this cookbook by
 running `git clone
-git://github.com/opscode-coobkooks/COOKBOOKNAME.git`.
+https://github.com/opscode-coobkooks/COOKBOOKNAME.git`.
 
 For collaboration purposes, it is best if you create a Github account
 and fork the repository to your own account. Once you do this you will

--- a/cookbooks/apache2/recipes/mod_auth_cas.rb
+++ b/cookbooks/apache2/recipes/mod_auth_cas.rb
@@ -10,7 +10,7 @@ if node['apache']['mod_auth_cas']['from_source']
   end
 
   git '/tmp/mod_auth_cas' do
-    repository 'git://github.com/Jasig/mod_auth_cas.git'
+    repository 'https://github.com/Jasig/mod_auth_cas.git'
     revision node['apache']['mod_auth_cas']['source_revision']
     notifies :run, 'execute[compile mod_auth_cas]', :immediately
   end

--- a/cookbooks/rbenv/README.md
+++ b/cookbooks/rbenv/README.md
@@ -135,7 +135,7 @@ To reference the Git version:
     ')
     cat >> Berksfile <<END_OF_BERKSFILE
     cookbook 'rbenv',
-      :git => 'git://github.com/$repo.git', :branch => '$latest_release'
+      :git => 'https://github.com/$repo.git', :branch => '$latest_release'
     END_OF_BERKSFILE
     berks install
 
@@ -158,7 +158,7 @@ To reference the Git version:
     ')
     cat >> Cheffile <<END_OF_CHEFFILE
     cookbook 'rbenv',
-      :git => 'git://github.com/$repo.git', :ref => '$latest_release'
+      :git => 'https://github.com/$repo.git', :ref => '$latest_release'
     END_OF_CHEFFILE
     librarian-chef install
 
@@ -222,7 +222,7 @@ wrapper script so Chef doesn't need to be re-installed in the global rbenv Ruby.
 
 The Git URL which is used to install rbenv.
 
-The default is `"git://github.com/sstephenson/rbenv.git"`.
+The default is `"https://github.com/sstephenson/rbenv.git"`.
 
 ### <a name="attributes-git-ref"></a> git_ref
 

--- a/cookbooks/rbenv/attributes/default.rb
+++ b/cookbooks/rbenv/attributes/default.rb
@@ -20,7 +20,7 @@
 #
 
 # git repository containing rbenv
-default['rbenv']['git_url'] = "git://github.com/sstephenson/rbenv.git"
+default['rbenv']['git_url'] = "https://github.com/sstephenson/rbenv.git"
 default['rbenv']['git_ref'] = "v0.4.0"
 
 # upgrade action strategy

--- a/cookbooks/ruby_build/README.md
+++ b/cookbooks/ruby_build/README.md
@@ -81,7 +81,7 @@ Or to reference the Git version:
     ')
     cat >> Berksfile <<END_OF_BERKSFILE
     cookbook 'ruby_build',
-      :git => 'git://github.com/$repo.git', :branch => '$latest_release'
+      :git => 'https://github.com/$repo.git', :branch => '$latest_release'
     END_OF_BERKSFILE
 
 ### <a name="installation-librarian"></a> Using Librarian-Chef
@@ -108,7 +108,7 @@ Or to reference the Git version:
     ')
     cat >> Cheffile <<END_OF_CHEFFILE
     cookbook 'ruby_build',
-      :git => 'git://github.com/$repo.git', :ref => '$latest_release'
+      :git => 'https://github.com/$repo.git', :ref => '$latest_release'
     END_OF_CHEFFILE
     librarian-chef install
 
@@ -125,7 +125,7 @@ Resources and Providers ([LWRPs][lwrp]).
 
 The Git URL which is used to install ruby-build.
 
-The default is `"git://github.com/sstephenson/ruby-build.git"`.
+The default is `"https://github.com/sstephenson/ruby-build.git"`.
 
 ### <a name="attributes-git-ref"></a> git_ref
 

--- a/site-cookbooks/wpcli/recipes/default.rb
+++ b/site-cookbooks/wpcli/recipes/default.rb
@@ -10,7 +10,7 @@ packages.each do |pkg|
 end
 
 git node[:wpcli][:dir] do
-  repository "git://github.com/wp-cli/builds.git"
+  repository "https://github.com/wp-cli/builds.git"
   action :sync
 end
 
@@ -44,7 +44,7 @@ template '/home/vagrant/.wp-cli/config.yml' do
 end
 
 git 'home/vagrant/.wp-cli/commands/dictator' do
-  repository "git://github.com/danielbachhuber/dictator.git"
+  repository "https://github.com/danielbachhuber/dictator.git"
   user node[:wpcli][:user]
   group node[:wpcli][:group]
   action :sync


### PR DESCRIPTION
Github's recommended way of cloning repo's is to use the HTTPS protocol, reasons are listed [here](https://help.github.com/articles/which-remote-url-should-i-use/). For me personally, the git:// protocol was blocked behind my corporate firewall, swapping to the HTTPS protocol fixed it for me.
