### PR TITLE
Movefile の local の vhost と wordpress_path の末尾につく / を削除

### DIFF
--- a/site-cookbooks/vccw/recipes/default.rb
+++ b/site-cookbooks/vccw/recipes/default.rb
@@ -191,8 +191,8 @@ template node[:vccw][:wordmove][:movefile] do
   group "vagrant"
   mode "0600"
   variables(
-    :url        => node[:vccw][:wordmove][:url],
-    :wpdir      => node[:vccw][:wordmove][:wpdir],
+    :url        => node[:vccw][:wordmove][:url].sub(/\/$/, ''),
+    :wpdir      => node[:vccw][:wordmove][:wpdir].sub(/\/$/, ''),
     :dbhost     => node[:vccw][:wordmove][:dbhost],
     :dbname     => node[:vccw][:wordmove][:dbname],
     :dbuser     => node[:vccw][:wordmove][:dbuser],


### PR DESCRIPTION
プロビジョニングしたときに生成される Movefile で、local の vhost の末尾に / がつきますが、staging の vhos の末尾には / が無く、統一せずに push すると画像の URL などがおかしなことになってしまったので、local の vhost も staging の vhost と同じように末尾は / 無しになるようにしてみました。
ついでに wordpress_path も同じ処理をしてみました。
