### PR TITLE
Add constant:WP_ALLOW_MULTISITE

### DIFF
--- a/provision/site-cookbooks/wpcli/recipes/install.rb
+++ b/provision/site-cookbooks/wpcli/recipes/install.rb
@@ -96,6 +96,10 @@ define( 'JETPACK_DEV_DEBUG', #{node[:wpcli][:debug_mode]} );
 define( 'WP_DEBUG', #{node[:wpcli][:debug_mode]} );
 define( 'FORCE_SSL_ADMIN', #{node[:wpcli][:force_ssl_admin]} );
 define( 'SAVEQUERIES', #{node[:wpcli][:savequeries]} );
+#{if node[:wpcli][:is_multisite] == true then <<MULTISITE
+define( 'WP_ALLOW_MULTISITE', true );
+MULTISITE
+end}
 PHP
   EOH
 end


### PR DESCRIPTION
`multisite: true` の際、マルチサイトを許可する設定になるよう定数を追加しました。