### PR TITLE
added AllowOverride directive

### DIFF
--- a/provision/site-cookbooks/wpcli/templates/default/wordpress.conf.erb
+++ b/provision/site-cookbooks/wpcli/templates/default/wordpress.conf.erb
@@ -6,7 +6,7 @@
 
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
-    AllowOverride FileInfo Options
+    AllowOverride FileInfo Options Limit
     Order allow,deny
     Allow from all
   </Directory>
@@ -35,7 +35,7 @@
 
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
-    AllowOverride FileInfo Options
+    AllowOverride FileInfo Options Limit
     Order allow,deny
     Allow from all
   </Directory>


### PR DESCRIPTION
特定のプラグインに関わる事象ですが、AllowOverride ディレクティブに Limit がないことで
[Really Simple CAPTCHA](https://wordpress.org/plugins/really-simple-captcha/) の CAPTCHA 画像が Internal Server Error で出力できないようです。レビューいただければ幸いです。

* 関連ポスト  
[WordPress &#8250; Support &raquo; Captcha image not loading](https://wordpress.org/support/topic/captcha-image-not-loading-1)