### PR TITLE
Duplicate definition prevention

### DIFF
--- a/provision/site-cookbooks/wpcli/recipes/install.rb
+++ b/provision/site-cookbooks/wpcli/recipes/install.rb
@@ -112,10 +112,6 @@ define( 'JETPACK_DEV_DEBUG', #{node[:wpcli][:debug_mode]} );
 define( 'WP_DEBUG', #{node[:wpcli][:debug_mode]} );
 define( 'FORCE_SSL_ADMIN', #{node[:wpcli][:force_ssl_admin]} );
 define( 'SAVEQUERIES', #{node[:wpcli][:savequeries]} );
-#{if node[:wpcli][:is_multisite] == true then <<MULTISITE
-define( 'WP_ALLOW_MULTISITE', true );
-MULTISITE
-end}
 PHP
   EOH
 end


### PR DESCRIPTION
When type "wp" command(multisite: true), it appear PHP Notice below.
"PHP Notice:  Constant WP_ALLOW_MULTISITE already defined in phar:///usr/share/wp-cli/phar/wp-cli.phar/php/wp-cli.php(23) : eval()'d code on line 44"