### PR TITLE
bump upload_max_filesize to 32M

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,7 +109,8 @@ Vagrant.configure(2) do |config|
             'mbstring.internal_encoding' => 'UTF-8',
             'date.timezone'              => 'UTC',
             'short_open_tag'             => 'Off',
-            'session.save_path'          => '/tmp'
+            'session.save_path'          => '/tmp',
+            'upload_max_filesize'        => '32M'
         }
       },
       :mysql => {


### PR DESCRIPTION
Allows uploading of 2015-sized themes, plugins, images, etc., and also allows for easy provisioning of one of the most commonly-modified WP needs.