### PR TITLE
Replace `--no-rdoc --no-ri` to `--no-document`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -170,19 +170,19 @@ Vagrant.configure(2) do |config|
           '2.1.2' => [
             {
               name: 'bundler',
-              options: '--no-ri --no-rdoc'
+              options: '--no-document'
             },
             {
               name: 'sass',
-              options: '--no-ri --no-rdoc'
+              options: '--no-document'
             },
             {
               name: 'wordmove',
-              options: '--no-ri --no-rdoc'
+              options: '--no-document'
             },
             {
               name: 'mailcatcher',
-              options: '--no-ri --no-rdoc'
+              options: '--no-document'
             }
           ]
         }

--- a/provision/cookbooks/rbenv/test/integration/system_ruby/bats/global_ruby.bats
+++ b/provision/cookbooks/rbenv/test/integration/system_ruby/bats/global_ruby.bats
@@ -31,7 +31,7 @@ setup() {
 
 @test "global Ruby can install nokogiri gem" {
   export RBENV_VERSION=$global_ruby
-  run gem install nokogiri --no-ri --no-rdoc
+  run gem install nokogiri --no-document
   [ $status -eq 0 ]
 }
 

--- a/provision/cookbooks/rbenv/test/integration/system_ruby/bats/ruby_envvars.bats
+++ b/provision/cookbooks/rbenv/test/integration/system_ruby/bats/ruby_envvars.bats
@@ -19,7 +19,7 @@ setup() {
   requires="require 'nokogiri';"
   script="$requires puts Nokogiri::HTML(open('$https_url')).css('input')"
 
-  run gem install nokogiri -v 1.5.11 --no-ri --no-rdoc
+  run gem install nokogiri -v 1.5.11 --no-document
   [ $status -eq 0 ]
 
   run ruby -rrubygems -ropen-uri -e "$script"

--- a/provision/cookbooks/rbenv/test/unit/resources/gem_spec.rb
+++ b/provision/cookbooks/rbenv/test/unit/resources/gem_spec.rb
@@ -53,8 +53,8 @@ describe Chef::Resource::RbenvGem do
   end
 
   it "attribute options takes a String value" do
-    resource.options("--no-rdoc")
-    expect(resource.options).to eq("--no-rdoc")
+    resource.options("--no-document")
+    expect(resource.options).to eq("--no-document")
   end
 
   it "attribute options takes a Hash value" do

--- a/provision/cookbooks/ruby_build/test/integration/alltherubies/bats/_verify_tests.bash
+++ b/provision/cookbooks/ruby_build/test/integration/alltherubies/bats/_verify_tests.bash
@@ -20,7 +20,7 @@ run_openssl_test() {
 }
 
 run_nokogiri_install_test() {
-  run gem install nokogiri --no-ri --no-rdoc
+  run gem install nokogiri --no-document
   [ $status -eq 0 ]
 }
 

--- a/provision/cookbooks/ruby_build/test/integration/alltherubies/bats/verify_jruby.bats
+++ b/provision/cookbooks/ruby_build/test/integration/alltherubies/bats/verify_jruby.bats
@@ -6,7 +6,7 @@ export def="$(basename $ruby_root)"
 load _verify_tests
 
 @test "Ruby $def can use openssl from stdlib" {
-  run gem install jruby-openssl --no-ri --no-rdoc
+  run gem install jruby-openssl --no-document
   [ $status -eq 0 ]
   run_openssl_test
 }


### PR DESCRIPTION
`--no-rdoc` and `--no-ri` is deprecated.
See: https://github.com/rubygems/rubygems/commit/0d22d602