### PR TITLE
Add development related plugins as default plugins.

### DIFF
--- a/provision/default.yml
+++ b/provision/default.yml
@@ -50,7 +50,7 @@ db_host: localhost
 # WordPress Default Plugins
 # Plugin's slug or url to the plugin's slug.
 #
-plugins: []
+plugins: ['theme-check', 'debug-bar']
 
 #
 # WordPress Default Theme


### PR DESCRIPTION
Since VCCW is for local development and wp_debug is set to true by default, why not specify some dev related plugins as default plugins*?

I would like to suggest:

- Theme Check: you need this when you develop a Theme for official repository, and officially maintained by make. teams.
- Debug Bar: it seems to be a default install for many developers, together with debug switched on.

(*we should keep the numbers to minimum.)