### PR TITLE
site.yml management at the outside of vccw.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,8 +27,8 @@ Vagrant.configure(2) do |config|
   end
 
   _site_config_files = [File.join(File.dirname(__FILE__), 'site.yml')]
-  if _conf.key?('site_config_path')
-    _site_config_files.unshift(File.expand_path(_conf['site_config_path']))
+  if _conf.key?('site_config_dir')
+    _site_config_files.unshift(File.join(File.expand_path(_conf['site_config_dir']), 'site.yml'))
   end
 
   _site_config_files.each do |file|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,14 +26,22 @@ Vagrant.configure(2) do |config|
     _conf.merge!(_custom) if _custom.is_a?(Hash)
   end
 
-  if File.exists?(File.join(File.dirname(__FILE__), 'site.yml'))
-    _site = YAML.load(
-      File.open(
-        File.join(File.dirname(__FILE__), 'site.yml'),
-        File::RDONLY
-      ).read
-    )
-    _conf.merge!(_site) if _site.is_a?(Hash)
+  _site_config_files = [File.join(File.dirname(__FILE__), 'site.yml')]
+  if _conf.key?('site_config_path')
+    _site_config_files.unshift(File.expand_path(_conf['site_config_path']))
+  end
+
+  _site_config_files.each do |file|
+    if File.exists?(file)
+      _site = YAML.load(
+        File.open(
+          file,
+          File::RDONLY
+        ).read
+      )
+      _conf.merge!(_site) if _site.is_a?(Hash)
+      break
+    end
   end
 
   # forcing config variables


### PR DESCRIPTION
I had wanted to manage my project like below:
```
my-project # <- git
├ vccw/ # <- e.g. submodule
├ site.yml
└ wordpress/
```
By defined like follows, ```wordpress/``` can be managed I want.
```
# site.yml
synced_folder: ../wordpress
```
But we could not of cours define at ```site.yml``` where ```site.yml``` is.

At this change, writing one line in ```~/.vccw/config.yml```, we'll be able to manage ```site.yml``` at the outside of vccw.
```
# ~/.vccw/config.yml
site_config_dir: ../ # Relative path from Vagrantfile
```