### PR TITLE
support vagrant-auto_network plugin to avoid IP collide.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,12 @@ Vagrant.configure(2) do |config|
   config.vm.box_check_update = true
 
   config.vm.hostname = _conf['hostname']
-  config.vm.network :private_network, ip: _conf['ip']
+  
+  if Vagrant.has_plugin?("auto_network")
+    config.vm.network :private_network, :auto_network => true
+  else
+    config.vm.network :private_network, ip: _conf['ip']
+  end
 
   config.vm.synced_folder _conf['synced_folder'],
       _conf['document_root'], :create => "true", :mount_options => ['dmode=755', 'fmode=644']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,10 @@ require 'yaml'
 
 Vagrant.require_version '>= 1.8.6'
 
+if Vagrant.has_plugin?("auto_network")
+  AutoNetwork.default_pool = '192.168.33.0/24'
+end
+
 Vagrant.configure(2) do |config|
 
   vccw_version = '3.0.10';


### PR DESCRIPTION
https://github.com/oscar-stack/vagrant-auto_network

support `vagrant-auto_network` plugin.
If you have installed `vagrant-auto_network` plugin, your new VMs don't collide IP Adress when you managing Multiple VMs.
This PR is settings for the plugin.
The operation has confirmed with version `1.0.2` of `vagrant-auto_network`.

---
Japanese

複数のVMを立ち上げる際に、IPアドレスが重複するとエラーが生じます。
が、 `vagrant-auto_network` プラグインをインストールしていれば、IPアドレスの衝突を回避する形で自動的にIPアドレスを割り当てる事が出来ます。
このプルリクは `vagrant-auto_network` の設定を書いた物です。
`vagrant-auto_network` の `1.0.2` で動作を確認しています。
