### PR TITLE
set phpunit version to 5.6

### DIFF
--- a/provision/default.yml
+++ b/provision/default.yml
@@ -119,8 +119,7 @@ npms: []
 # composer
 #
 composers:
-  - hirak/prestissimo:*
-  - phpunit/phpunit:*
+  - phpunit/phpunit:5.6
   - squizlabs/php_codesniffer:*
   - wp-coding-standards/wpcs:*
   # - phpmd/phpmd:*


### PR DESCRIPTION
PHPUnit 7.0 doesn't have compatible with WP_Unittestcase.
So we have to force 5.6 it.