### PR TITLE
Fixed theme install skip

### DIFF
--- a/provision/playbooks/wordpress.yml
+++ b/provision/playbooks/wordpress.yml
@@ -134,7 +134,7 @@
     command: |
       wp theme install {{ vccw.theme }}
       --path={{ path }} --activate
-    when: vccw.theme != '' and theme_is_installed.stdout == "1"
+    when: vccw.theme != '' and theme_is_installed.rc == 1
 
   - name: Run `wp theme activate`
     command: |


### PR DESCRIPTION
http://wp-cli.org/commands/theme/is-installed/
error to theme install.
check result to is-installed command is return code, and stdout not be done write.

