### PR TITLE
replace domain .dev -> .local

### DIFF
--- a/provision/default.yml
+++ b/provision/default.yml
@@ -15,7 +15,7 @@ cpus: 1
 #
 # Network Settings
 #
-hostname: vccw.dev
+hostname: vccw.local
 ip: 192.168.33.10
 
 #


### PR DESCRIPTION
Related issue: #275
Replace the default domain `.dev` to `.local`.

If we should be use another domain name, please close the PR.