### PR TITLE
Changed default TLD to .test

### DIFF
--- a/provision/default.yml
+++ b/provision/default.yml
@@ -15,7 +15,7 @@ cpus: 1
 #
 # Network Settings
 #
-hostname: vccw.dev
+hostname: vccw.test
 ip: 192.168.33.10
 
 #


### PR DESCRIPTION
Changed the default TLD to .test as .dev is no longer suitable for dev env.