### PR TITLE
WordPress Importer from Github master branch.

### DIFF
--- a/provision/playbooks/wordpress.yml
+++ b/provision/playbooks/wordpress.yml
@@ -132,9 +132,9 @@
     when: vccw.theme != ''
 
   # Import Theme Unit Test Data
-  - name: Run `wp plugin install wordpress-importer`
+  - name: Install `wordpress-importer`
     command: |
-      wp plugin install wordpress-importer
+      wp plugin install https://github.com/WordPress/wordpress-importer/archive/master.zip
       --activate
       --path={{ path }}
     when: vccw.theme_unit_test


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/36281

Fails to import menu items in PHP7 in WordPress Importer 0.6.3.

Replace importer to development version.