### PR TITLE
Add aliases and always run options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,4 +115,8 @@ Vagrant.configure(2) do |config|
   if File.exists?(File.join(File.dirname(__FILE__), 'provision-post.sh')) then
     config.vm.provision :shell, :privileged => false, :path => File.join( File.dirname(__FILE__), 'provision-post.sh' )
   end
+
+  if File.exists?(File.join(File.dirname(__FILE__), 'run-always.sh')) then
+    config.vm.provision :shell, :path => File.join( File.dirname(__FILE__), 'run-always.sh' ), run: 'always'
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,7 @@ Vagrant.configure(2) do |config|
       SharedFoldersEnableSymlinksCreate: false
 
   if Vagrant.has_plugin?('vagrant-hostsupdater')
+    config.hostsupdater.aliases = _conf['hostname_aliases']
     config.hostsupdater.remove_on_suspend = true
   end
 

--- a/provision/default.yml
+++ b/provision/default.yml
@@ -19,6 +19,14 @@ hostname: vccw.test
 ip: 192.168.33.10
 
 #
+# Vagrant Hostsupdater Aliases
+# Manage additional entries in the /etc/hosts file using vagrant-hostsupdater
+#
+hostname_aliases:
+  - www.vccw.test
+#  - some.subdomain.vccw.test
+
+#
 # WordPress Settings
 #
 version: latest


### PR DESCRIPTION
- Allow users to define multiple domains with vagrant-hostsupdater aliases. Especially useful for WordPress multisite. 
- Add option to run commands always on startup with run-always.sh, not just pre/post provision.