### PR TITLE
Check for .git directory, suppress destructive actions to shared folder 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,4 +115,8 @@ Vagrant.configure(2) do |config|
   if File.exists?(File.join(File.dirname(__FILE__), 'provision-post.sh')) then
     config.vm.provision :shell, :privileged => false, :path => File.join( File.dirname(__FILE__), 'provision-post.sh' )
   end
+
+  if File.exists?(File.join(File.dirname(__FILE__), 'run-always.sh')) then
+    config.vm.provision :shell, :path => File.join( File.dirname(__FILE__), 'run-always.sh' ), run: 'always'
+  end
 end

--- a/provision/default.yml
+++ b/provision/default.yml
@@ -83,12 +83,12 @@ savequeries: false
 gitignore: https://raw.githubusercontent.com/github/gitignore/master/WordPress.gitignore
 
 #
-# Addtional PHP code in the wp-config.php
+# Additional PHP code in the wp-config.php
 #
 extra_wp_config: |
-  // Addtional PHP code in the wp-config.php
+  // Additional PHP code in the wp-config.php
   // These lines are inserted by VCCW.
-  // You can place addtional PHP code here!
+  // You can place additional PHP code here!
 
 #
 # Theme unit testing


### PR DESCRIPTION
Check for .git directory in shared folder, suppress destructive actions on provision if it is a git repo. Most users will not notice any change, but users that put their own WordPress repo (git) in the shared folder will notice that it stays the same on provision. 